### PR TITLE
Changed wording of requirements for members to use names

### DIFF
--- a/membership-of-the-hackspace.rst
+++ b/membership-of-the-hackspace.rst
@@ -15,7 +15,7 @@ If you decide to no longer be a member, please empty your box first. The Hackspa
 
 **Members must follow and agree to all rules**, and membership can be revoked through the grievance procedure.
 
-Nottingham Hackspace Ltd is required under Companies Act [#]_ to keep a record of all members legal name and current address. We use HMS (Hackspace Members System) website [#]_ to keep this information, it is very important that you keep this up-to-date, including your email address [#]_ for contact purpose
+Nottingham Hackspace Ltd is required under Companies Act [#]_ to keep a record of name and current address for all members. We use HMS (Hackspace Members System) website [#]_ to keep this information, it is very important that you keep this up-to-date, including your email address [#]_ for contact purpose
 
 
 .. [#] Companies Act 2006 http://www.legislation.gov.uk/ukpga/2006/46/contents

--- a/storage-in-the-hackspace.rst
+++ b/storage-in-the-hackspace.rst
@@ -3,7 +3,7 @@ Storage in the Hackspace
 
 Remember that the **Hackspace has limited storage space**. We have designated storage space for **consumables, resources** and **members’ storage**.
 
-Members are entitled to a **35l storage box**. You can buy a box from any of the Membership Team or Trustees for £5. You must label your box with your full name - please do not use a pseudonym. A contact method (such as email) is also appreciated on the label, to help identify the owner of a box.
+Members are entitled to a **35l storage box**. You can buy a box from any of the Membership Team or Trustees for £5. You must label your box with an identifiable name - any name is fine as long as we can identify the owner by it. A current, up-to-date contact method (such as email) is also useful to get in touch quickly.
 
 If you are working on a project that is too large for a 35l box you can store it on the Large Project Shelves. It can be stored there whilst it is actively being worked on, and must always be labelled according to our **Do Not Hack** rules.
 

--- a/storage-in-the-hackspace.rst
+++ b/storage-in-the-hackspace.rst
@@ -3,7 +3,7 @@ Storage in the Hackspace
 
 Remember that the **Hackspace has limited storage space**. We have designated storage space for **consumables, resources** and **members’ storage**.
 
-Members are entitled to a **35l storage box**. You can buy a box from any of the Membership Team or Trustees for £5. You must label your box with an identifiable name - any name is fine as long as we can identify the owner by it. A current, up-to-date contact method (such as email) is also useful to get in touch quickly.
+Members are entitled to a **35l storage box**. You can buy a box from any of the Membership Team or Trustees for £5. You must label your box with an identifiable name - any name is fine as long as we can uniquely identify the owner by it. A current, up-to-date contact method (such as email) is also useful to get in touch quickly.
 
 If you are working on a project that is too large for a 35l box you can store it on the Large Project Shelves. It can be stored there whilst it is actively being worked on, and must always be labelled according to our **Do Not Hack** rules.
 


### PR DESCRIPTION
membership-of-the-hackspace.rst - I removed the word "legal" from "legal name", since the Companies Act doesn't use the term "legal name", just "name" for the register of members (as far as I can tell).

storage-in-the-hackspace.rst - changed "full name" to "identifiable name". Also, made it that the optional email address was about communication, not identification.