### PR TITLE
Remove summaries and clean up main page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@
 Nottingham Hackspace Rules
 ==========================
 
-Welcome to the Nottingham Hackspace Rules. This contains the rules to which every member and guest of the space is expected to follow. They do not define what you can do, only what you must do.  All members are expected to have an awareness of the rules, and confirm that they are understood when becoming a member. If you're ever unsure, you should always ask, either by emailing the trustees, or by asking on Discord in the appropriate channel.
+Welcome to the Nottingham Hackspace Rules. This contains the rules to which every member and guest of the space is expected to follow. They do not define what you can do, only what you must not do.  All members are expected to have an awareness of the rules, and confirm that they are understood when becoming a member. If you're ever unsure, you should always ask, either by emailing the trustees, or by asking on Discord in the appropriate channel.
 
 There are nine core rules,
 

--- a/index.rst
+++ b/index.rst
@@ -6,41 +6,34 @@
 Nottingham Hackspace Rules
 ==========================
 
-Welcome to the Nottingham Hackspace Rules. This contains the rules to which every member and guest of the space is expected to follow.
+Welcome to the Nottingham Hackspace Rules. This contains the rules to which every member and guest of the space is expected to follow. They do not define what you can do, only what you must do.  All members are expected to have an awareness of the rules, and confirm that they are understood when becoming a member. If you're ever unsure, you should always ask, either by emailing the trustees, or by asking on Discord in the appropriate channel.
 
-Below is a summary of the rules, each has its own full description that can be accessed via the menu on the left.
+There are nine core rules,
 
+- Rule 0: `Do Not Be On Fire <do-not-be-on-fire.html>`_
+- Rule 1: `Membership of the Hackspace <membership-of-the-hackspace.html>`_
+- Rule 2: `Guests & Visitors <guests-and-visitors.html>`_
+- Rule 3: `Be Excellent to One Another <be-excellent-to-one-another.html>`_
+- Rule 4: `Respect the Hackspace <respect-the-hackspace.html>`_
+- Rule 5: `Do Not Hack <do-not-hack.html>`_
+- Rule 6: `UK Legislation <uk-legislation.html>`_
+- Rule 7: `Storage in the Hackspace <storage-in-the-hackspace.html>`_
+- Rule 8: `Donating Items to Nottingham Hackspace <donating-to-nottingham-hackspace.html>`_
 
-0. Rule 0: Do Not Be On Fire
-    It is essential you use the Space safely as a responsible adult.
-1. Membership of the Hackspace
-    Any person aged 18 or over can join Nottingham Hackspace, by visiting on a open night, providing correct details, and setting up and maintaining a monthly payment into our nominated bank account.
-2. Guests & Visitors
-    Guests & visitors are **welcome in the Hackspace**. However whoever brings them into the space or lets them into the Space is **wholly responsible for them**.
-3. Be Excellent To One Another
-    We ask that you respect others when using the Hackspace. Do this by **cleaning up after yourself**, abiding by our **safe spaces** policy and **code of conduct**.
-4. Respect the Hackspace
-    We ask that you respect the Hackspace. Do this by **cleaning up after yourself**, by being careful not to **damage infrastructure** and by **reporting both damaged/broken tools and infrastructure**.
-5. Do Not Hack
-    Do Not Hack is an integral part of the Hackspace. Do Not Hack means you are claiming materials, a donation or a project as your own, and requesting that no other members 'hack' the component parts.
-6. UK Legislation
-    Whilst in the Hackspace you must abide by all applicable UK laws and legislation.
-7. Storage in the Hackspace
-    Remember that the **Hackspace has limited storage space**. We have designated storage space for **consumables, resources** and **members’ storage**.
-8. Donating Items to Nottingham Hackspace
-    **Consider the benefit to the Nottingham Hackspace** when making a donation. Do this by posting your items and offers in the appropriate channel on Discord. Is there a general consensus from the members about its use or usefulness?
+Additionally, there are four appendices,
 
-Appendices
-----------
+- Appendix A: `Complaints Policy <complaints-policy.html>`_
+- Appendix B: `SafeSpaces Policy <safespaces.html>`_
+- Appendix C: `Discord Policy <discord.html>`_
+- Appendix D: `GDPR and Privacy Policy <privacy.html>`_
 
-A. Complaints Policy
-    This is the policy followed by the Trustees when we receive a complaint.
-B. SafeSpaces Policy
-    This policy sets out what behaviour is inappropriate in that it may amount to harassment.
-C. Discord Policy
-    This policy sets out acceptable conduct in the Hackspace Discord Server.
-D. GDPR and Privacy Policy
-    How your information is used to provide access to the hackspace.
+We also maintain a `list of definitions <definitions.html>`_.
+
+Contributing
+------------
+
+Contributions to the rules are welcome. There are instructions on how to do this on our `GitHub <https://github.com/NottingHack/rules>`_. Please be willing to engage in discussion about your proposal. Your changes can be merged if the board vote to approve the change.
+
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
This change removes the summaries from the main page, which has apparently caused confusion on several occasions. It also replaces them with links, making it easier to browse using a phone and highlighting that there is more information (rather than the summary, as before).