### PR TITLE
Added sleeping rule as core rule for accessibility/visibility

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,7 +8,7 @@ Nottingham Hackspace Rules
 
 Welcome to the Nottingham Hackspace Rules. This contains the rules which every member and guest of the space is expected to follow. They do not define what you can do, only what you must not do.  All members are expected to have an awareness of the rules, and confirm that they are understood when becoming a member. If you're ever unsure, you should always ask, either by emailing the trustees, or by asking on Discord in the appropriate channel.
 
-There are nine core rules,
+There are ten core rules,
 
 - Rule 0: `Do Not Be On Fire <do-not-be-on-fire.html>`_
 - Rule 1: `Membership of the Hackspace <membership-of-the-hackspace.html>`_
@@ -19,6 +19,7 @@ There are nine core rules,
 - Rule 6: `UK Legislation <uk-legislation.html>`_
 - Rule 7: `Storage in the Hackspace <storage-in-the-hackspace.html>`_
 - Rule 8: `Donating Items to Nottingham Hackspace <donating-to-nottingham-hackspace.html>`_
+- Rule 9: `No Sleeping <sleeping.html>`_
 
 Additionally, there are four appendices,
 
@@ -49,6 +50,7 @@ Contributions to the rules are welcome. There are instructions on how to do this
     Rule 6. UK Legislation <uk-legislation>
     Rule 7. Storage in the Hackspace <storage-in-the-hackspace>
     Rule 8. Donating Items to Nottingham Hackspace <donating-to-nottingham-hackspace>
+    Rule 9. No Sleeping <sleeping>
     Appendix A: Complaints Policy <complaints-policy>
     Appendix B: SafeSpaces Policy <safespaces>
     Appendix C: Discord Policy <discord>

--- a/sleeping.rst
+++ b/sleeping.rst
@@ -1,0 +1,4 @@
+No Sleeping
+===========
+
+**Sleeping** at any time (even if it's a short nap) will result in a permanent ban - we have a zero tolerance policy on this. Sleeping in the space jeopardises our lease agreement, breaches fire regulations and is a risk to your personal safety.


### PR DESCRIPTION
The sleeping rule has the most extreme penalty of all the Hackspace rules (immediate permanent ban without warning) and yet until now it's been hidden away under a section nobody reads. An informal survey of several members has highlighted that very few people were aware of the severity of this rule (or that it covers naps as well as overnight sleeping). In particular, members who are deaf did not know this rule existed at all because it's shared verbally during the Hackspace tour, and being deaf they did not hear it. The Hackspace rules need to be accessible to people with disabilities, and therefore a visible, written, easy-to-find version of the rule is necessary.

If you are thinking, 'the rule is written under the UK Legislation section so we don't need it elsewhere' - there are a number of reasons why this is inadequate:

1. People already know UK laws and legislation so they assume they don't need to read this section and will skip it;
2. People are busy and don't have time to read every word on the rules site so they skim or skip things;
3. Many members are autistic, ADD or otherwise neurodivergent and don't have the attention span to read through the entire rules site. This again is an accessibility issue;
4. Even when people are intentionally trying to find the 'no sleeping' rule, they have difficulty finding it because it's miscategorised. There is no UK legislation against sleeping. The UK legislation says no *living* in a commercial space, which is not the same as a complete ban on sleeping. As it's not UK legislation, people don't think to look for it there.

For all these reasons, the sleeping rule is best placed as a core rule so it's visible and accessible. This also gives confidence that people will actually see the rule and therefore it's less likely to be broken.